### PR TITLE
Fixing Issue #5

### DIFF
--- a/ieeg/dataset.py
+++ b/ieeg/dataset.py
@@ -209,8 +209,7 @@ class Dataset:
                            for numeric_string in r.headers['voltage-conversion-factors-mv'].split(',')])
 
         # Reshape to 2D array and Multiply by conversionFactor
-        d2 = np.transpose(np.reshape(d, (len(sample_per_row), -1))) * conv_f[np.newaxis, :]
-
+        d2 = np.reshape(d, (-1, len(sample_per_row)), order='F') * conv_f[np.newaxis, :]
 
         return d2
 

--- a/ieeg/dataset.py
+++ b/ieeg/dataset.py
@@ -69,7 +69,7 @@ class Annotation:
         layer: The layer
         start_time_offset_usec: The start time of this Annotations.
                                 In microseconds since the recording start.
-        end_time_offset_usec: The end time of this Annotation. 
+        end_time_offset_usec: The end time of this Annotation.
                               In microseconds since the recording start.
     """
 
@@ -209,7 +209,8 @@ class Dataset:
                            for numeric_string in r.headers['voltage-conversion-factors-mv'].split(',')])
 
         # Reshape to 2D array and Multiply by conversionFactor
-        d2 = np.reshape(d, (-1, len(sample_per_row))) * conv_f[np.newaxis, :]
+        d2 = np.transpose(np.reshape(d, (len(sample_per_row), -1))) * conv_f[np.newaxis, :]
+
 
         return d2
 


### PR DESCRIPTION
numpy reshape() is not correctly used. It causes the 2D array returned from get_data() does not have the raw data of channels in the correct positions. (As described in Issue #5 ). I fixed it by changing the use of reshape() and also add transpose() to make sure columns of the 2D array are channels, while rows are samples across the channels.