### PR TITLE
Exceptions Update

### DIFF
--- a/ieeg/auth.py
+++ b/ieeg/auth.py
@@ -67,10 +67,6 @@ class Session:
         Returns the montages associated with this Dataset.
         """
         response = self.api.get_montages(dataset_id)
-        if response.status_code != requests.codes.ok:
-            print(response.text)
-            raise IeegConnectionError(
-                'Could not get montages')
         response_body = response.json()
         # If there is just one montage, response will be a single
         # montage and not an array.

--- a/ieeg/auth.py
+++ b/ieeg/auth.py
@@ -18,8 +18,8 @@
 import xml.etree.ElementTree as ET
 from deprecation import deprecated
 import requests
-from ieeg.dataset import Dataset as DS, IeegConnectionError
-from ieeg.ieeg_api import IeegApi
+from ieeg.dataset import Dataset as DS
+from ieeg.ieeg_api import IeegApi, IeegConnectionError
 
 class Session:
     """
@@ -85,12 +85,6 @@ class Session:
         """
 
         get_id_response = self.api.get_dataset_id_by_name(name)
-
-        # Check response
-        if get_id_response.status_code != 200:
-            print(get_id_response.text)
-            raise IeegConnectionError(
-                'Authorization failed or cannot find study ' + name)
 
         snapshot_id = get_id_response.text
 

--- a/ieeg/auth.py
+++ b/ieeg/auth.py
@@ -17,9 +17,8 @@
 
 import xml.etree.ElementTree as ET
 from deprecation import deprecated
-import requests
 from ieeg.dataset import Dataset as DS
-from ieeg.ieeg_api import IeegApi, IeegConnectionError
+from ieeg.ieeg_api import IeegApi
 
 class Session:
     """
@@ -87,10 +86,6 @@ class Session:
         time_series_details_response = self.api.get_time_series_details(
             snapshot_id)
 
-        if time_series_details_response.status_code != 200:
-            print(time_series_details_response.text)
-            raise IeegConnectionError('Authorization failed or cannot get time series details for ' +
-                                      name)
         json_montages = self._get_montages(snapshot_id)
         dataset = DS(name, ET.fromstring(
             time_series_details_response.text), snapshot_id, self, json_montages=json_montages)

--- a/ieeg/dataset.py
+++ b/ieeg/dataset.py
@@ -18,6 +18,7 @@ import requests
 import numpy as np
 import pandas as pd
 from deprecation import deprecated
+from ieeg.ieeg_api import IeegConnectionError
 
 
 class TimeSeriesDetails:
@@ -608,15 +609,3 @@ class Dataset:
     @deprecated
     def getData(self, start, duration, channels):
         return self.get_data(start, duration, channels)
-
-
-class IeegConnectionError(Exception):
-    """
-    A simple exception for connectivity errors
-    """
-
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self):
-        return repr(self.value)

--- a/ieeg/dataset.py
+++ b/ieeg/dataset.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 ##################################################################################
 from collections import namedtuple
-import requests
 import numpy as np
 import pandas as pd
 from deprecation import deprecated
@@ -341,13 +340,8 @@ class Dataset:
         :param tool_name: The name of the tool creating the dataset
         :return: A new Dataset which is a copy of this dataset and which has the given name.
         """
-        response = self.session.api.derive_dataset(self,
-                                                   derived_dataset_name, tool_name)
-        if response.status_code != 200:
-            print(response.text)
-            raise IeegConnectionError(
-                'Cannot create derived Dataset ' + derived_dataset_name)
-
+        self.session.api.derive_dataset(self,
+                                        derived_dataset_name, tool_name)
         return self.session.open_dataset(derived_dataset_name)
 
     def get_channel_labels(self):
@@ -482,11 +476,6 @@ class Dataset:
 
         # response to request
         response = self.session.api.get_annotation_layers(self)
-        if response.status_code != requests.codes.ok:
-            print(response.text)
-            raise IeegConnectionError(
-                'Could not get annotation layers for dataset')
-
         response_body = response.json()
         counts_by_layer = response_body['countsByLayer']['countsByLayer']
         if not counts_by_layer:
@@ -521,10 +510,6 @@ class Dataset:
                                                     start_offset_usecs=start_offset_usecs,
                                                     first_result=first_result,
                                                     max_results=max_results)
-        if response.status_code != requests.codes.ok:
-            print(response.text)
-            raise IeegConnectionError(
-                'Could not get annotation layer ' + layer_name)
         response_body = response.json()
         timeseries_annotations = response_body['timeseriesannotations']
         json_annotations = timeseries_annotations['annotations']['annotation']
@@ -560,12 +545,7 @@ class Dataset:
         """
         Adds a collection of Annotations to this dataset.
         """
-        response = self.session.api.add_annotations(self, annotations)
-        if response.status_code != requests.codes.ok:
-            response_body = response.text
-            print(response_body)
-            raise IeegConnectionError(
-                'Could not add annotations')
+        self.session.api.add_annotations(self, annotations)
         if self.session.mprov_listener:
             self.session.mprov_listener.on_add_annotations(annotations)
 
@@ -577,11 +557,6 @@ class Dataset:
         """
         response = self.session.api.move_annotation_layer(
             self, from_layer, to_layer)
-        if response.status_code != requests.codes.ok:
-            response_body = response.text
-            print(response_body)
-            raise IeegConnectionError(
-                'Could not move annotation layer ' + from_layer + ' to ' + to_layer)
         response_body = response.json()
         moved = response_body['tsAnnotationsMoved']['moved']
         return int(moved)
@@ -593,11 +568,6 @@ class Dataset:
         :returns: the number of deleted annotations.
         """
         response = self.session.api.delete_annotation_layer(self, layer)
-        if response.status_code != requests.codes.ok:
-            response_body = response.text
-            print(response_body)
-            raise IeegConnectionError(
-                'Could not delete annotation layer ' + layer)
         response_body = response.json()
         deleted = response_body['tsAnnotationsDeleted']['noDeleted']
         return int(deleted)

--- a/ieeg/ieeg_api.py
+++ b/ieeg/ieeg_api.py
@@ -63,7 +63,10 @@ class IeegApi:
         """
         url = self.base_url + IeegApi._get_id_by_dataset_name_path + dataset_name
 
-        response = self.http.get(url)
+        response = self.http.get(url, headers=IeegApi._accept_json)
+        # Check response
+        if response.status_code != 200:
+            raise IeegServiceError(response.status_code, response.json())
         return response
 
     def get_time_series_details(self, dataset_id):
@@ -247,3 +250,20 @@ class IeegApi:
 
         response = self.http.post(url_str, headers=IeegApi._accept_json)
         return response
+
+class IeegConnectionError(Exception):
+    """
+    A simple exception for connectivity errors
+    """
+
+class IeegServiceError(IeegConnectionError):
+    """
+    An error resopnse was recieved from the server.
+    """
+
+    def __init__(self, status_code, ieegWsExceptionBody):
+        self.status_code = status_code
+        body = ieegWsExceptionBody['IeegWsException']
+        self.error_code = body['errorCode']
+        message = body['message']
+        super(IeegServiceError, self).__init__(message)

--- a/ieeg/ieeg_api.py
+++ b/ieeg/ieeg_api.py
@@ -293,7 +293,9 @@ class IeegServiceError(IeegConnectionError):
         """
         Returns IeegServiceError from the given json content
         """
-        content = json_ieeg_ws_exception_body['IeegWsException']
+        content = json_ieeg_ws_exception_body.get('IeegWsException')
+        if not content:
+            return IeegConnectionError(json_ieeg_ws_exception_body)
         ieeg_error_code = content['errorCode']
         message = content['message']
         return IeegServiceError(http_status, ieeg_error_code, message)
@@ -304,6 +306,9 @@ class IeegServiceError(IeegConnectionError):
         Returns IeegServiceError from the given xml content
         """
         content = ET.fromstring(xml_ieeg_ws_exception_body)
-        ieeg_error_code = content.find('errorCode').text
+        ieeg_error_code_element = content.find('errorCode')
+        if not ieeg_error_code_element:
+            return IeegConnectionError(xml_ieeg_ws_exception_body)
+        ieeg_error_code = ieeg_error_code_element.text
         message = content.find('message').text
         return IeegServiceError(http_status, ieeg_error_code, message)

--- a/ieeg/ieeg_api.py
+++ b/ieeg/ieeg_api.py
@@ -174,6 +174,8 @@ class IeegApi:
         url_str = self.base_url + IeegApi._get_montages_path % dataset_id
 
         response = self.http.get(url_str, headers=IeegApi._accept_json)
+        if response.status_code != requests.codes.ok:
+            raise IeegServiceError.from_json(response.status_code, response.json())
         return response
 
     def add_annotations(self, dataset, annotations):

--- a/ieeg/ieeg_api.py
+++ b/ieeg/ieeg_api.py
@@ -60,6 +60,7 @@ class IeegApi:
         """
         Raises error if http status code is not 200
         """
+        # Get a runtime error if the unused args are removed from sig.
         #pylint: disable=unused-argument
         if response.status_code != requests.codes.ok:
             content_type = response.headers.get('Content-Type')

--- a/ieeg/ieeg_api.py
+++ b/ieeg/ieeg_api.py
@@ -65,7 +65,7 @@ class IeegApi:
 
         response = self.http.get(url, headers=IeegApi._accept_json)
         # Check response
-        if response.status_code != 200:
+        if response.status_code != requests.codes.ok:
             raise IeegServiceError.from_json(response.status_code, response.json())
         return response
 
@@ -75,6 +75,8 @@ class IeegApi:
         """
         url = self.base_url + IeegApi._get_time_series_details_path + dataset_id
         response = self.http.get(url, headers=IeegApi._accept_xml)
+        if response.status_code != requests.codes.ok:
+            raise IeegServiceError.from_xml(response.status_code, response.text)
         return response
 
     def get_annotation_layers(self, dataset):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='ieeg',
-      version='1.4.3',
+      version='1.5',
       description='API for the IEEG.org platform',
       install_requires=['deprecation','requests','numpy','pandas', 'pennprov==2.2.2'],
       packages=setuptools.find_packages(),


### PR DESCRIPTION
Moved IeegConnectionError to from ieeg.dataset to ieeg.ieeg_api. 

Introduced subclass, IeegServiceError, which contains the http_status_code and ieeg_error_code to allow clients to make decisions when handling exceptions from server. (See examples/mprov_example.py for an example.)

Removed printing of server error response. Now in the Exception that is thrown.

Configure requests.Session with an error handler to centralize the creation of these Exceptions.